### PR TITLE
Fix download url for modules

### DIFF
--- a/src/main/java/api/Modules.java
+++ b/src/main/java/api/Modules.java
@@ -79,8 +79,7 @@ public class Modules {
           throws StorageException {
     Module module = new Module(namespace, name, provider, version);
     String path = StorageUtil.generateModuleStoragePath(module);
-    String signedUrl = storageService.getDownloadUrlForArtifact(path);
-    String downloadUrl = String.format("s3::%s", signedUrl);
+    String downloadUrl = storageService.getDownloadUrlForArtifact(path);
     eventBus.requestAndForget("module.download.requested", module);
     return Response.noContent().header("X-Terraform-Get", downloadUrl).build();
   }

--- a/src/test/java/api/ModulesTest.java
+++ b/src/test/java/api/ModulesTest.java
@@ -68,6 +68,6 @@ class ModulesTest {
             when().get(fakeUrl)
             .then()
             .statusCode(204)
-            .header("X-Terraform-Get","s3::https://fakeurl");
+            .header("X-Terraform-Get","https://fakeurl");
   }
 }


### PR DESCRIPTION
# Description

No need to prefix modules anymore with s3:// as this would break all storage option besides the s3 one

relates to #364 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)