### PR TITLE
fix: Ensure report can be parsed with findings.

### DIFF
--- a/src/main/java/extensions/security/report/SecurityFinding.java
+++ b/src/main/java/extensions/security/report/SecurityFinding.java
@@ -3,6 +3,7 @@ package extensions.security.report;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -24,6 +25,10 @@ public class SecurityFinding {
   private Integer status;
   private String resource;
   private Location location;
+
+  public SecurityFinding() {
+
+  }
 
   public SecurityFinding(
       String id, String qualifiedId, String ruleDescription, String provider,
@@ -164,6 +169,10 @@ public class SecurityFinding {
     private Integer startLine;
     @JsonProperty("end_line")
     private Integer endLine;
+
+    public Location() {
+
+    }
 
     public Location(String fileName, Integer startLine, Integer endLine) {
       this.fileName = fileName;

--- a/src/test/java/extensions/core/ReportTest.java
+++ b/src/test/java/extensions/core/ReportTest.java
@@ -23,8 +23,7 @@ class ReportTest {
         try (Reader reader = new InputStreamReader(Objects.requireNonNull(TestDataBuilder.class
                 .getResourceAsStream("/securityReport.json")))) {
             json = new BufferedReader(reader).lines().collect(Collectors.joining());
-
-        }catch (IOException e) {
+        } catch (IOException e) {
             e.printStackTrace();
             return;
         }

--- a/src/test/java/extensions/core/ReportTest.java
+++ b/src/test/java/extensions/core/ReportTest.java
@@ -1,0 +1,55 @@
+package extensions.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import extensions.docs.report.TerraformDocumentation;
+import extensions.security.report.SecurityFinding;
+import org.junit.jupiter.api.Test;
+import util.TestDataBuilder;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ReportTest {
+    @Test
+    void canParse() throws Exception {
+        final String json;
+        try (Reader reader = new InputStreamReader(Objects.requireNonNull(TestDataBuilder.class
+                .getResourceAsStream("/securityReport.json")))) {
+            json = new BufferedReader(reader).lines().collect(Collectors.joining());
+
+        }catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        var mapper = new ObjectMapper();
+        var report = mapper.readValue(json, Report.class);
+
+        // Assertions to verify the parsed object
+        assertNotNull(report);
+        assertEquals("azure", report.getModuleNamespace());
+        assertEquals("foo", report.getModuleName());
+        assertEquals("1.0.0", report.getModuleVersion());
+        assertEquals("azurerm", report.getProvider());
+
+        var securityReport = report.getSecurityReport();
+        assertNotNull(securityReport);
+        assertEquals(1, securityReport.get("main.tf").size());
+        SecurityFinding finding = securityReport.get("main.tf").get(0);
+        assertEquals("AVD-AZU-0014", finding.getId());
+
+        TerraformDocumentation documentation = report.getDocumentation();
+        assertNotNull(documentation);
+        assertEquals(1, documentation.getProviders().size());
+        assertEquals("azurerm", documentation.getProviders().get(0).getName());
+        assertEquals(1, documentation.getResources().size());
+        assertEquals("mykey", documentation.getResources().get(0).getName());
+    }
+}

--- a/src/test/resources/securityReport.json
+++ b/src/test/resources/securityReport.json
@@ -1,0 +1,53 @@
+{
+  "id": "azure-foo-azurerm-1.0.0",
+  "moduleName": "foo",
+  "moduleVersion": "1.0.0",
+  "moduleNamespace": "azure",
+  "provider": "azurerm",
+  "securityReport": {
+    "main.tf": [
+      {
+        "id": "AVD-AZU-0014",
+        "qualifiedId": "AVD-AZU-0014",
+        "provider": "Azure",
+        "service": "keyvault",
+        "impact": "Expiration Date is an optional Key Vault Key behavior and is not set by default.\n\nSet when the resource will be become inactive.",
+        "resolution": "Set an expiration date on the vault key",
+        "links": [
+          "https://docs.microsoft.com/en-us/powershell/module/az.keyvault/update-azkeyvaultkey?view=azps-5.8.0#example-1--modify-a-key-to-enable-it--and-set-the-expiration-date-and-tags",
+          "https://avd.aquasec.com/misconfig/avd-azu-0014"
+        ],
+        "description": "Ensure that the expiration date is set on all keys",
+        "severity": "MEDIUM",
+        "warning": false,
+        "status": 0,
+        "resource": "azurerm_key_vault_key.mykey",
+        "location": {
+          "fileName": "main.tf",
+          "start_line": 1,
+          "end_line": 9
+        },
+        "rule_description": "Key should have an expiry date specified."
+      }
+    ]
+  },
+  "documentation": {
+    "inputs": [],
+    "modules": [],
+    "outputs": [],
+    "providers": [
+      {
+        "name": "azurerm"
+      }
+    ],
+    "resources": [
+      {
+        "name": "mykey",
+        "type": "key_vault_key",
+        "source": "hashicorp/azurerm",
+        "mode": "managed",
+        "version": "latest"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Description

Fixes a crash when viewing a module with a security finding. I've added a basic test to JSON parse a real(ish) data.

Fixes https://github.com/PacoVK/tapir/issues/403.

## Type of change

Please **delete** options that are **not** relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
