### PR TITLE
feat: implement scopable deploy keys

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,14 +8,14 @@ Tapir integrates well with [Keycloak](https://www.keycloak.org/).
 
 Tapir management needs the IDP client to put the role `admin` into the token.
 
-Tapir supports authentication via [OIDC](https://openid.net/connect/) and Deploy-Keys.
-While OIDC secures the app and Tapir management, Deploy-Keys are used for the REST-API in a CI/CD context.
+Tapir supports authentication via [OIDC](https://openid.net/connect/) and [Deploy-Keys](./usage.md#deploy-keys).
+While OIDC secures the app and Tapir management, [Deploy-Keys](./usage.md#deploy-keys) are used for the REST-API in a CI/CD context.
 
 **NOTE**: To use Tapir UI you need to be authenticated. However, you can read the registry without authentication. In particular the Terraform CLI will work without authentication, since Tapir does not yet support the [Login API](https://developer.hashicorp.com/terraform/internals/login-protocol).
 
 ##### OIDC vs. DeployKey
 
-The OIDC mechanism is used for the UI and Tapir management, while DeployKeys are used for the REST-API to publish modules and providers only.
+The OIDC mechanism is used for the UI and Tapir management, while [Deploy-Keys](./usage.md#deploy-keys) are used for the REST-API to publish modules and providers only.
 
 #### Backend
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,10 +1,72 @@
+### Deploy-Keys
+
+
+Deploy Keys are used to authenticate upload requests. When creating a deploy key, you need to provide the following parameters:
+
+- **`resource-type`**: Specifies whether the deploy key is for a `module` or a `provider`.
+- **`source`**: The location of the module or provider, typically a Git repository.
+- **`scope`**: Defines the access level for the deploy key, allowing fine-grained control.
+- **`namespace`**: The namespace of the resource (applies to both `module` and `provider`).
+- **`name`**: The name of the resource (applies to `module`).
+- **`type`**: The type of resource (applies to `provider`).
+- **`provider`**: The provider of the resource (applies to `module`).
+
+#### Scope
+
+The scope parameter determines the hierarchy of access. You can choose the level of granularity for the deploy key based on the resource type.
+
+Resource hierarchy:
+- **Module**: `<namespace>/<name>/<provider>`
+- **Provider**: `<namespace>/<type>`
+
+Depending on the resource type, you can set the scope to one of these levels. The deploy key will grant access to all resources under the specified scope.
+
+##### Examples
+
+Given the following resources:
+
+- `tapir/networking/aws`
+- `tapir/networking/azure`
+- `tapir/compute/aws`
+- `tapir/compute/azure`
+- `anta/networking/aws`
+- `anta/networking/azure`
+- `anta/compute/aws`
+- `anta/compute/azure`
+
+1. **Scope: `namespace` (e.g., `namespace == tapir`)**
+
+   A deploy key with this scope would grant access to all `tapir` resources:
+
+  - `tapir/networking/aws`
+  - `tapir/networking/azure`
+  - `tapir/compute/aws`
+  - `tapir/compute/azure`
+
+2. **Scope: `name` (e.g., `namespace == anta`, `name == compute`)**
+
+   This scope limits access to the `compute` resources within the `anta` namespace:
+
+  - `anta/compute/aws`
+  - `anta/compute/azure`
+
+3. **Scope: `provider` (e.g., `namespace == tapir`, `name == networking`, `provider == azure`)**
+
+   This would restrict access to only the `tapir/networking/azure` module.
+
+  - `tapir/networking/azure`
+
+#### Legacy Deploy keys.
+
+Before version `0.9`, deploy keys were not **scopable**. While it is recommended to migrate to scopable keys, legacy deploy keys remain valid. They are treated as the most restrictive scope (`provider` for `modules` and `type` for `providers`), limiting access to a specific resource.
+
 ### Upload a module or provider
 
-To upload a module or provider you need to be authenticated via DeployKey. A DeployKey can be created and managed by Tapir administrators (see [authentication prerequisites](./configuration.md#Prerequisites)). After creating deploy keys, you can use them to authenticate against the REST-API. There is one DeployKey per namespace.
+To upload a module or provider you need to be authenticated via [DeployKey](#deploy-keys)
 
 #### Upload a module
 
-When you publish a Terraform module, a corresponding DeployKey must be created first.
+When you publish a Terraform module, you need a [DeployKey](#deploy-keys) giving permission to the new module.
 
 ##### Prerequisites:
 * The package name and version must be unique in the top-level namespace.
@@ -50,7 +112,8 @@ curl -XPOST  -H 'x-api-key: <API_KEY>' --fail-with-body -F archive=@archive.zip 
 > **Kubernetes:** kubernetes <br/>
 
 #### Upload a provider
-When you publish a Terraform provider, a corresponding DeployKey must be created first.
+When you publish a Terraform provider, you need a [DeployKey](#deploy-keys) giving permission to the new provider.
+
 
 Looking for the [troubleshooting docs](./TROUBLESHOOT.md)?
 

--- a/src/main/java/api/Management.java
+++ b/src/main/java/api/Management.java
@@ -4,6 +4,7 @@ package api;
 import core.exceptions.TapirException;
 import core.service.DeployKeyService;
 import core.tapir.DeployKey;
+import core.tapir.DeployKeyScope;
 import core.terraform.Module;
 import core.upload.FormData;
 import extensions.core.Report;
@@ -39,7 +40,7 @@ public class Management {
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Path("/deploykey")
   public Response createDeployKey(  @RestForm String resourceType,
-  @RestForm String scope,
+  @RestForm DeployKeyScope scope,
   @RestForm String namespace,
   @RestForm String source,
   @RestForm String provider,

--- a/src/main/java/core/backend/IRepository.java
+++ b/src/main/java/core/backend/IRepository.java
@@ -34,6 +34,8 @@ public interface IRepository {
 
   DeployKey getDeployKeyById(String id) throws DeployKeyNotFoundException;
 
+  DeployKey getDeployKeyByValue(String value) throws DeployKeyNotFoundException;
+
   void saveDeployKey(DeployKey deployKey) throws Exception;
 
   void updateDeployKey(DeployKey deployKey) throws Exception;

--- a/src/main/java/core/backend/aws/dynamodb/repository/DynamodbRepository.java
+++ b/src/main/java/core/backend/aws/dynamodb/repository/DynamodbRepository.java
@@ -6,12 +6,15 @@ import core.exceptions.DeployKeyNotFoundException;
 import core.exceptions.ModuleNotFoundException;
 import core.exceptions.ProviderNotFoundException;
 import core.exceptions.ReportNotFoundException;
+import core.tapir.CoreEntity;
 import core.tapir.DeployKey;
 import core.terraform.Module;
 import core.terraform.Provider;
 import extensions.core.Report;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -252,6 +255,14 @@ public class DynamodbRepository extends TapirRepository {
       throw new DeployKeyNotFoundException(id);
     }
     return deployKey;
+  }
+
+  public DeployKey getDeployKeyByValue(String value) throws DeployKeyNotFoundException {
+    Collection<DeployKey> deployKeys = (Collection<DeployKey>) findDeployKeys("", 1, value).getEntities();
+    if (deployKeys == null || deployKeys.size() != 1) {
+      throw new DeployKeyNotFoundException("Could not find matching key");
+    }
+    return deployKeys.stream().findFirst().orElseThrow(() -> new DeployKeyNotFoundException("Could not find matching key"));
   }
 
   public void deleteDeployKey(String id) {

--- a/src/main/java/core/backend/azure/cosmosdb/CosmosDbRepository.java
+++ b/src/main/java/core/backend/azure/cosmosdb/CosmosDbRepository.java
@@ -19,6 +19,7 @@ import core.exceptions.DeployKeyNotFoundException;
 import core.exceptions.ModuleNotFoundException;
 import core.exceptions.ProviderNotFoundException;
 import core.exceptions.ReportNotFoundException;
+import core.tapir.CoreEntity;
 import core.tapir.DeployKey;
 import core.terraform.Module;
 import core.terraform.Provider;
@@ -26,6 +27,8 @@ import extensions.core.Report;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -246,6 +249,19 @@ public class CosmosDbRepository extends TapirRepository {
     } catch (NotFoundException cosmosException) {
       throw new DeployKeyNotFoundException(id, cosmosException);
     }
+  }
+
+  @Override
+  public DeployKey getDeployKeyByValue(String value) throws DeployKeyNotFoundException {
+      try {
+          Collection<DeployKey> deployKeys = (Collection<DeployKey>) findDeployKeys("", 1, value).getEntities();
+          if (deployKeys == null || deployKeys.size() != 1) {
+            throw new DeployKeyNotFoundException("Could not find matching key");
+          }
+          return deployKeys.stream().findFirst().orElseThrow(() -> new DeployKeyNotFoundException("Could not find matching key"));
+      } catch (Exception e) {
+          throw new DeployKeyNotFoundException("Could not find matching key");
+      }
   }
 
   @Override

--- a/src/main/java/core/backend/elasticsearch/ElasticSearchRepository.java
+++ b/src/main/java/core/backend/elasticsearch/ElasticSearchRepository.java
@@ -17,6 +17,7 @@ import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.HttpMethod;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
@@ -85,6 +86,19 @@ public class ElasticSearchRepository extends TapirRepository {
     } catch (IOException e) {
       throw new DeployKeyNotFoundException(id, e);
     }
+  }
+
+  @Override
+  public DeployKey getDeployKeyByValue(String value) throws DeployKeyNotFoundException {
+      try {
+        Collection<DeployKey> deployKeys = (Collection<DeployKey>) findDeployKeys("", 1, value).getEntities();
+        if (deployKeys == null || deployKeys.size() != 1) {
+          throw new DeployKeyNotFoundException("Could not find matching key");
+        }
+        return deployKeys.stream().findFirst().orElseThrow(() -> new DeployKeyNotFoundException("Could not find matching key"));
+      } catch (Exception e) {
+        throw new DeployKeyNotFoundException("Could not find matching key");
+      }
   }
 
   @Override

--- a/src/main/java/core/service/DeployKeyService.java
+++ b/src/main/java/core/service/DeployKeyService.java
@@ -4,6 +4,7 @@ import api.dto.PaginationDto;
 import core.backend.TapirRepository;
 import core.exceptions.DeployKeyNotFoundException;
 import core.tapir.DeployKey;
+import core.tapir.DeployKeyScope;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import java.time.Instant;
@@ -18,14 +19,14 @@ public class DeployKeyService {
     this.tapirRepository = searchServiceInstance.get();
   }
 
-  public DeployKey createModuleDeployKey(String scope, String source, String namespace, String name, String provider) throws Exception {
+  public DeployKey createModuleDeployKey(DeployKeyScope scope, String source, String namespace, String name, String provider) throws Exception {
     DeployKey deployKey = new DeployKey(scope, source, namespace, name, provider, generateKey());
     deployKey.setLastModifiedAt(Instant.now());
     tapirRepository.saveDeployKey(deployKey);
     return deployKey;
   }
 
-  public DeployKey createProviderDeployKey(String scope, String source, String namespace, String type) throws Exception {
+  public DeployKey createProviderDeployKey(DeployKeyScope scope, String source, String namespace, String type) throws Exception {
     DeployKey deployKey = new DeployKey(scope, source, namespace, type, generateKey());
     deployKey.setLastModifiedAt(Instant.now());
     tapirRepository.saveDeployKey(deployKey);

--- a/src/main/java/core/service/DeployKeyService.java
+++ b/src/main/java/core/service/DeployKeyService.java
@@ -18,8 +18,15 @@ public class DeployKeyService {
     this.tapirRepository = searchServiceInstance.get();
   }
 
-  public DeployKey createDeployKey(String id) throws Exception {
-    DeployKey deployKey = new DeployKey(id, generateKey());
+  public DeployKey createModuleDeployKey(String scope, String source, String namespace, String name, String provider) throws Exception {
+    DeployKey deployKey = new DeployKey(scope, source, namespace, name, provider, generateKey());
+    deployKey.setLastModifiedAt(Instant.now());
+    tapirRepository.saveDeployKey(deployKey);
+    return deployKey;
+  }
+
+  public DeployKey createProviderDeployKey(String scope, String source, String namespace, String type) throws Exception {
+    DeployKey deployKey = new DeployKey(scope, source, namespace, type, generateKey());
     deployKey.setLastModifiedAt(Instant.now());
     tapirRepository.saveDeployKey(deployKey);
     return deployKey;
@@ -35,6 +42,10 @@ public class DeployKeyService {
 
   public DeployKey getDeployKey(String id) throws DeployKeyNotFoundException {
     return tapirRepository.getDeployKeyById(id);
+  }
+
+  public DeployKey getDeployKeyByValue(String value) throws DeployKeyNotFoundException {
+    return tapirRepository.getDeployKeyById(value);
   }
 
   public void deleteDeployKey(String id) throws Exception {

--- a/src/main/java/core/tapir/DeployKey.java
+++ b/src/main/java/core/tapir/DeployKey.java
@@ -76,6 +76,12 @@ public class DeployKey extends CoreEntity {
     if (!Objects.equals(this.resourceType, "module")) {
       return false;
     }
+    // Let's support the legacy keys
+    if (this.scope == null) {
+      // Let's reconstruct the expected key id
+      String expectedKeyId = String.format("%s-%s-%s", module.getNamespace(), module.getName(), module.getProvider());
+      return Objects.equals(this.id, expectedKeyId);
+    }
     // Let's first validate the namespace
     if (!Objects.equals(this.namespace, module.getNamespace())) {
       return false;
@@ -97,6 +103,12 @@ public class DeployKey extends CoreEntity {
   public boolean ValidForProvider(Provider provider) {
     if (!Objects.equals(this.resourceType, "provider")) {
       return false;
+    }
+    // Let's support the legacy keys
+    if (this.scope == null) {
+      // Let's reconstruct the expected key id
+      String expectedKeyId = String.format("%s-%s", provider.getNamespace(), provider.getType());
+      return Objects.equals(this.id, expectedKeyId);
     }
     if (!Objects.equals(this.namespace, provider.getNamespace())) {
       return false;

--- a/src/main/java/core/tapir/DeployKey.java
+++ b/src/main/java/core/tapir/DeployKey.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 
 public class DeployKey extends CoreEntity {
   String resourceType;
-  String scope;
+  DeployKeyScope scope;
   String source;
   String namespace;
   String provider;
@@ -22,7 +22,7 @@ public class DeployKey extends CoreEntity {
 
   public DeployKey() {}
 
-  public DeployKey(String scope, String source, String namespace, String name, String provider, String key) {
+  public DeployKey(DeployKeyScope scope, String source, String namespace, String name, String provider, String key) {
     this.scope = scope;
     this.source = source;
     this.namespace = namespace;
@@ -33,7 +33,7 @@ public class DeployKey extends CoreEntity {
     setId(new ArrayList<>(Arrays.asList(this.resourceType, this.namespace, this.name, this.provider)));
   }
 
-  public DeployKey(String scope, String source, String namespace, String type, String key) {
+  public DeployKey(DeployKeyScope scope, String source, String namespace, String type, String key) {
     this.scope = scope;
     this.source = source;
     this.namespace = namespace;
@@ -80,14 +80,14 @@ public class DeployKey extends CoreEntity {
     if (!Objects.equals(this.namespace, module.getNamespace())) {
       return false;
     }
-    if (Objects.equals(this.scope, "namespace")) {
+    if (Objects.equals(this.scope, DeployKeyScope.NAMESPACE)) {
       // no need to go furter
       return true;
     }
     if (!Objects.equals(this.name, module.getName())) {
       return false;
     }
-    if (Objects.equals(this.scope, "name")) {
+    if (Objects.equals(this.scope, DeployKeyScope.NAME)) {
       // no need to go furter
       return true;
     }
@@ -101,7 +101,7 @@ public class DeployKey extends CoreEntity {
     if (!Objects.equals(this.namespace, provider.getNamespace())) {
       return false;
     }
-    if (Objects.equals(this.scope, "namespace")) {
+    if (Objects.equals(this.scope,  DeployKeyScope.NAMESPACE)) {
       // no need to check further
       return true;
     }

--- a/src/main/java/core/tapir/DeployKey.java
+++ b/src/main/java/core/tapir/DeployKey.java
@@ -1,18 +1,46 @@
 package core.tapir;
 
+import core.terraform.Module;
+import core.terraform.Provider;
+
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
 
 public class DeployKey extends CoreEntity {
-
-  String id;
+  String resourceType;
+  String scope;
+  String source;
+  String namespace;
+  String provider;
+  String name;
+  String type;
   String key;
+  String id;
   Instant lastModifiedAt;
 
   public DeployKey() {}
 
-  public DeployKey(String id, String key) {
-    this.id = id;
+  public DeployKey(String scope, String source, String namespace, String name, String provider, String key) {
+    this.scope = scope;
+    this.source = source;
+    this.namespace = namespace;
+    this.name = name;
+    this.provider = provider;
+    this.resourceType = "module";
     this.key = key;
+    setId(new ArrayList<>(Arrays.asList(this.resourceType, this.namespace, this.name, this.provider)));
+  }
+
+  public DeployKey(String scope, String source, String namespace, String type, String key) {
+    this.scope = scope;
+    this.source = source;
+    this.namespace = namespace;
+    this.type = type;
+    this.resourceType = "provider";
+    this.key = key;
+    setId(new ArrayList<>(Arrays.asList(this.resourceType, this.namespace, this.type)));
   }
 
   public String getId() {
@@ -21,6 +49,11 @@ public class DeployKey extends CoreEntity {
 
   public void setId(String id) {
     this.id = id;
+  }
+
+  public void setId(ArrayList<String> idTokens) {
+    idTokens.removeAll(Arrays.asList("", null));
+    this.id = String.join("-", idTokens);
   }
 
   public String getKey() {
@@ -37,5 +70,41 @@ public class DeployKey extends CoreEntity {
 
   public void setLastModifiedAt(Instant lastModifiedAt) {
     this.lastModifiedAt = lastModifiedAt;
+  }
+
+  public boolean ValidForModule(Module module) {
+    if (!Objects.equals(this.resourceType, "module")) {
+      return false;
+    }
+    // Let's first validate the namespace
+    if (!Objects.equals(this.namespace, module.getNamespace())) {
+      return false;
+    }
+    if (Objects.equals(this.scope, "namespace")) {
+      // no need to go furter
+      return true;
+    }
+    if (!Objects.equals(this.name, module.getName())) {
+      return false;
+    }
+    if (Objects.equals(this.scope, "name")) {
+      // no need to go furter
+      return true;
+    }
+    return !Objects.equals(this.provider, module.getProvider());
+  }
+
+  public boolean ValidForProvider(Provider provider) {
+    if (!Objects.equals(this.resourceType, "provider")) {
+      return false;
+    }
+    if (!Objects.equals(this.namespace, provider.getNamespace())) {
+      return false;
+    }
+    if (Objects.equals(this.scope, "namespace")) {
+      // no need to check further
+      return true;
+    }
+    return Objects.equals(this.type, provider.getType());
   }
 }

--- a/src/main/java/core/tapir/DeployKeyScope.java
+++ b/src/main/java/core/tapir/DeployKeyScope.java
@@ -1,0 +1,8 @@
+package core.tapir;
+
+public enum DeployKeyScope {
+  NAMESPACE,
+  NAME,
+  PROVIDER,
+  TYPE,
+}

--- a/src/test/java/api/ManagementTest.java
+++ b/src/test/java/api/ManagementTest.java
@@ -3,6 +3,7 @@ package api;
 import core.exceptions.DeployKeyNotFoundException;
 import core.service.DeployKeyService;
 import core.tapir.DeployKey;
+import core.tapir.DeployKeyScope;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
@@ -27,7 +28,7 @@ public class ManagementTest {
 
   @Test
   void getDeployKey() throws DeployKeyNotFoundException {
-    DeployKey fake = new DeployKey("namespace", "", "foo", "", "fake");
+    DeployKey fake = new DeployKey(DeployKeyScope.NAMESPACE, "", "foo", "", "fake");
     fake.setLastModifiedAt(Instant.parse("2023-01-01T00:00:00Z"));
     when(deployKeyService.getDeployKey(any())).thenReturn(fake);
     given().get("/deploykey/foo-bar")

--- a/src/test/java/api/ManagementTest.java
+++ b/src/test/java/api/ManagementTest.java
@@ -27,14 +27,14 @@ public class ManagementTest {
 
   @Test
   void getDeployKey() throws DeployKeyNotFoundException {
-    DeployKey fake = new DeployKey("foo-bar", "fake");
+    DeployKey fake = new DeployKey("namespace", "", "foo", "", "fake");
     fake.setLastModifiedAt(Instant.parse("2023-01-01T00:00:00Z"));
     when(deployKeyService.getDeployKey(any())).thenReturn(fake);
     given().get("/deploykey/foo-bar")
         .then()
         .statusCode(200)
         .body(
-            "\"id\"", is("foo-bar"),
+            "\"id\"", is("provider-foo"),
             "\"key\"", is("fake"),
             "\"lastModifiedAt\"", is("2023-01-01T00:00:00Z")
         );

--- a/src/test/java/core/backend/AbstractDeployKeysBackendTest.java
+++ b/src/test/java/core/backend/AbstractDeployKeysBackendTest.java
@@ -3,6 +3,8 @@ package core.backend;
 import api.dto.PaginationDto;
 import core.tapir.DeployKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import core.tapir.DeployKeyScope;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +23,7 @@ public abstract class AbstractDeployKeysBackendTest {
 
   @Test
   void saveAndUpdateDeployKey() throws Exception {
-    DeployKey deployKey = new DeployKey("namespace", "", "mae", "", "son");
+    DeployKey deployKey = new DeployKey(DeployKeyScope.NAMESPACE, "", "mae", "", "son");
     repository.saveDeployKey(deployKey);
     DeployKey persistedDeployKey = repository.getDeployKeyById(deployKey.getId());
     assertEquals(deployKey.getId(), persistedDeployKey.getId());
@@ -35,8 +37,8 @@ public abstract class AbstractDeployKeysBackendTest {
 
   @Test
   void findDeployKeys() throws Exception {
-    DeployKey deployKey1 = new DeployKey("namespace", "", "foo", "", "bar");
-    DeployKey deployKey2 = new DeployKey("namespace", "", "fred", "", "flintStone");
+    DeployKey deployKey1 = new DeployKey(DeployKeyScope.NAMESPACE, "", "foo", "", "bar");
+    DeployKey deployKey2 = new DeployKey(DeployKeyScope.NAMESPACE, "", "fred", "", "flintStone");
 
     repository.saveDeployKey(deployKey1);
     repository.saveDeployKey(deployKey2);

--- a/src/test/java/core/backend/AbstractDeployKeysBackendTest.java
+++ b/src/test/java/core/backend/AbstractDeployKeysBackendTest.java
@@ -21,7 +21,7 @@ public abstract class AbstractDeployKeysBackendTest {
 
   @Test
   void saveAndUpdateDeployKey() throws Exception {
-    DeployKey deployKey = new DeployKey("mae", "son");
+    DeployKey deployKey = new DeployKey("namespace", "", "mae", "", "son");
     repository.saveDeployKey(deployKey);
     DeployKey persistedDeployKey = repository.getDeployKeyById(deployKey.getId());
     assertEquals(deployKey.getId(), persistedDeployKey.getId());
@@ -35,8 +35,8 @@ public abstract class AbstractDeployKeysBackendTest {
 
   @Test
   void findDeployKeys() throws Exception {
-    DeployKey deployKey1 = new DeployKey("foo", "bar");
-    DeployKey deployKey2 = new DeployKey("fred", "flintstone");
+    DeployKey deployKey1 = new DeployKey("namespace", "", "foo", "", "bar");
+    DeployKey deployKey2 = new DeployKey("namespace", "", "fred", "", "flintStone");
 
     repository.saveDeployKey(deployKey1);
     repository.saveDeployKey(deployKey2);

--- a/src/test/java/core/backend/aws/dynamodb/repository/DynamodbDeployKeyRepositoryTest.java
+++ b/src/test/java/core/backend/aws/dynamodb/repository/DynamodbDeployKeyRepositoryTest.java
@@ -2,6 +2,7 @@ package core.backend.aws.dynamodb.repository;
 
 import core.backend.AbstractDeployKeysBackendTest;
 import core.tapir.DeployKey;
+import core.tapir.DeployKeyScope;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -30,7 +31,7 @@ class DynamodbDeployKeyRepositoryTest extends AbstractDeployKeysBackendTest {
 
   @Test
   void cannotOverwriteDeployKey() throws Exception {
-    DeployKey deployKey = new DeployKey("namespace", "", "double", "", "dcore");
+    DeployKey deployKey = new DeployKey(DeployKeyScope.NAMESPACE, "", "double", "", "dcore");
     repository.saveDeployKey(deployKey);
     DeployKey persistedDeployKey = repository.getDeployKeyById(deployKey.getId());
     persistedDeployKey.setKey("changed");

--- a/src/test/java/core/backend/aws/dynamodb/repository/DynamodbDeployKeyRepositoryTest.java
+++ b/src/test/java/core/backend/aws/dynamodb/repository/DynamodbDeployKeyRepositoryTest.java
@@ -30,7 +30,7 @@ class DynamodbDeployKeyRepositoryTest extends AbstractDeployKeysBackendTest {
 
   @Test
   void cannotOverwriteDeployKey() throws Exception {
-    DeployKey deployKey = new DeployKey("double", "dcore");
+    DeployKey deployKey = new DeployKey("namespace", "", "double", "", "dcore");
     repository.saveDeployKey(deployKey);
     DeployKey persistedDeployKey = repository.getDeployKeyById(deployKey.getId());
     persistedDeployKey.setKey("changed");


### PR DESCRIPTION
# Description

implements #395

## Type of change

Please **delete** options that are **not** relevant.

- [ ] New feature (non-breaking change which adds functionality)


## Improvements
@PacoVK I tested the PR and it works fairly well, the only remaining issues is the migration of existing keys. Is there already a migration mechanism in place? Migrating a key to the scopable one is easy, I just did not find where i could put the logic