### PR TITLE
fix: deploykeyscope validation should be case insensitive

### DIFF
--- a/src/main/java/api/auth/ApiKeyAuthenticationMechanism.java
+++ b/src/main/java/api/auth/ApiKeyAuthenticationMechanism.java
@@ -85,21 +85,13 @@ public class ApiKeyAuthenticationMechanism implements HttpAuthenticationMechanis
   }
   private boolean validateKeyByRequestPath(DeployKey key, String requestPath) {
     String resourceId = requestPath.split("/v1/")[1];
+    String[] split = resourceId.split("/");
     if (requestPath.contains("modules")) {
-      try {
-        Module module = moduleService.getModule(resourceId);
-        return key.ValidForModule(module);
-      } catch (Exception e) {
-        return false;
-      }
+      Module module = new Module(split[0], split[1], split[2]);
+      return key.ValidForModule(module);
     } else {
-        Provider provider = null;
-        try {
-            provider = providerService.getProvider(resourceId);
-        } catch (Exception e) {
-          return false;
-        }
-        return key.ValidForProvider(provider);
+      Provider provider = new Provider(split[0], split[1]);
+      return key.ValidForProvider(provider);
     }
   }
 

--- a/src/main/java/core/service/DeployKeyService.java
+++ b/src/main/java/core/service/DeployKeyService.java
@@ -46,7 +46,7 @@ public class DeployKeyService {
   }
 
   public DeployKey getDeployKeyByValue(String value) throws DeployKeyNotFoundException {
-    return tapirRepository.getDeployKeyById(value);
+    return tapirRepository.getDeployKeyByValue(value);
   }
 
   public void deleteDeployKey(String id) throws Exception {

--- a/src/main/java/core/tapir/DeployKey.java
+++ b/src/main/java/core/tapir/DeployKey.java
@@ -72,6 +72,30 @@ public class DeployKey extends CoreEntity {
     this.lastModifiedAt = lastModifiedAt;
   }
 
+  public DeployKeyScope getScope() {
+    return scope;
+  }
+
+  public String getResourceType() {
+    return resourceType;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
   public boolean ValidForModule(Module module) {
     if (!Objects.equals(this.resourceType, "module")) {
       return false;

--- a/src/main/java/core/tapir/DeployKeyScope.java
+++ b/src/main/java/core/tapir/DeployKeyScope.java
@@ -4,5 +4,20 @@ public enum DeployKeyScope {
   NAMESPACE,
   NAME,
   PROVIDER,
-  TYPE,
+  TYPE;
+
+
+  public static DeployKeyScope fromString(String scope)  {
+     if (scope == null || scope.isEmpty()) {
+       return null;
+     }
+
+     for (DeployKeyScope keyScope: DeployKeyScope.values()) {
+       if (keyScope.name().equalsIgnoreCase(scope)) {
+         return keyScope;
+       }
+     }
+     return null;
+
+  }
 }


### PR DESCRIPTION
# Description

fix #449 by handling case insensitive validation of the enum. The mapping ehaviour is documented in [quarkus](https://quarkus.io/guides/rest#parameter-mapping).

I've tested this by building the docker image and deploying it

## Type of change

Please **delete** options that are **not** relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
