### PR TITLE
feat: allow to use minio as an aws s3 provider

### DIFF
--- a/src/main/java/core/storage/aws/S3StorageRepository.java
+++ b/src/main/java/core/storage/aws/S3StorageRepository.java
@@ -7,15 +7,23 @@ import core.terraform.Module;
 import core.terraform.Provider;
 import core.upload.FormData;
 import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.logging.Logger;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.endpoints.S3EndpointParams;
+import software.amazon.awssdk.services.s3.endpoints.S3EndpointProvider;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -33,11 +41,45 @@ public class S3StorageRepository extends StorageRepository {
 
   @ConfigProperty(name = "registry.storage.s3.bucket.name")
   String bucketName;
+  @ConfigProperty(name = "registry.storage.s3.custom_endpoint")
+  Optional<String> customEndpoint;
+  @ConfigProperty(name = "registry.storage.s3.use_path_style_access", defaultValue = "false")
+  boolean usePathStyleAccess;
 
+  @PostConstruct
+  public void initialize() {
+    var region = DefaultAwsRegionProviderChain.builder().build().getRegion();
+    var credentials = DefaultCredentialsProvider.create();
+    S3ClientBuilder s3ClientBuilder = S3Client.builder()
+      .credentialsProvider(credentials)
+      .region(region);
+    var s3PresignerBuilder = S3Presigner.builder()
+      .credentialsProvider(credentials)
+      .region(region);
+    if (!customEndpoint.isEmpty()) {
+      var endpointParams = S3EndpointParams.builder()
+        .endpoint(customEndpoint.get())
+        .region(region)
+        .build();
 
-  public S3StorageRepository(S3Client s3, S3Presigner presigner) {
-    this.s3 = s3;
-    this.presigner = presigner;
+      var endpoint = S3EndpointProvider
+        .defaultProvider()
+        .resolveEndpoint(endpointParams).join();
+
+      s3ClientBuilder.endpointOverride(endpoint.url());
+      s3PresignerBuilder.endpointOverride(endpoint.url());
+    }
+
+    if (usePathStyleAccess) {
+      s3ClientBuilder.forcePathStyle(true);
+      s3PresignerBuilder.serviceConfiguration(
+        S3Configuration.builder().pathStyleAccessEnabled(true).build()
+      );
+    }
+
+    this.s3 = s3ClientBuilder.build();
+    this.presigner = s3PresignerBuilder.build();
+
   }
 
   @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,8 @@ registry:
       blobConnectionString: ${AZURE_BLOB_CONNECTION_STRING:DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;}
       containerName: ${AZURE_BLOB_CONTAINER_NAME:tf-registry}
     s3:
+      custom_endpoint: ${S3_STORAGE_CUSTOM_ENDPOINT}
+      use_path_style_access: ${S3_STORAGE_USE_PATH_STYLE_ACCESS:false}
       bucket:
         name: ${S3_STORAGE_BUCKET_NAME:tf-registry}
         region: ${S3_STORAGE_BUCKET_REGION:eu-central-1}


### PR DESCRIPTION
# Description

Add minimum config value that allows for minio to be used instead of s3.

Has been tested on our prod deployment

## Type of change


- [x] New feature (non-breaking change which adds functionality)

