### PR TITLE
fix: add missing deploy key fields to DynamoDB schema (#514)

### DIFF
--- a/src/main/java/core/backend/aws/dynamodb/repository/TableSchemas.java
+++ b/src/main/java/core/backend/aws/dynamodb/repository/TableSchemas.java
@@ -1,6 +1,7 @@
 package core.backend.aws.dynamodb.repository;
 
 import core.tapir.DeployKey;
+import core.tapir.DeployKeyScope;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primaryPartitionKey;
 
 import core.backend.aws.dynamodb.converter.ArtifactVersionsConverter;
@@ -109,6 +110,27 @@ public class TableSchemas {
                           .getter(DeployKey::getId)
                           .setter(DeployKey::setId)
                           .tags(primaryPartitionKey()))
+                  .addAttribute(String.class, a -> a.name("resourceType")
+                          .getter(DeployKey::getResourceType)
+                          .setter(DeployKey::setResourceType))
+                  .addAttribute(String.class, a -> a.name("scope")
+                          .getter(k -> k.getScope() != null ? k.getScope().name() : null)
+                          .setter((k, v) -> k.setScope(v != null ? DeployKeyScope.valueOf(v) : null)))
+                  .addAttribute(String.class, a -> a.name("source")
+                          .getter(DeployKey::getSource)
+                          .setter(DeployKey::setSource))
+                  .addAttribute(String.class, a -> a.name("namespace")
+                          .getter(DeployKey::getNamespace)
+                          .setter(DeployKey::setNamespace))
+                  .addAttribute(String.class, a -> a.name("provider")
+                          .getter(DeployKey::getProvider)
+                          .setter(DeployKey::setProvider))
+                  .addAttribute(String.class, a -> a.name("name")
+                          .getter(DeployKey::getName)
+                          .setter(DeployKey::setName))
+                  .addAttribute(String.class, a -> a.name("type")
+                          .getter(DeployKey::getType)
+                          .setter(DeployKey::setType))
                   .addAttribute(String.class, a -> a.name("key")
                           .getter(DeployKey::getKey)
                           .setter(DeployKey::setKey))

--- a/src/main/java/core/tapir/DeployKey.java
+++ b/src/main/java/core/tapir/DeployKey.java
@@ -76,24 +76,56 @@ public class DeployKey extends CoreEntity {
     return scope;
   }
 
+  public void setScope(DeployKeyScope scope) {
+    this.scope = scope;
+  }
+
   public String getResourceType() {
     return resourceType;
+  }
+
+  public void setResourceType(String resourceType) {
+    this.resourceType = resourceType;
+  }
+
+  public String getSource() {
+    return source;
+  }
+
+  public void setSource(String source) {
+    this.source = source;
   }
 
   public String getNamespace() {
     return namespace;
   }
 
+  public void setNamespace(String namespace) {
+    this.namespace = namespace;
+  }
+
   public String getProvider() {
     return provider;
+  }
+
+  public void setProvider(String provider) {
+    this.provider = provider;
   }
 
   public String getName() {
     return name;
   }
 
+  public void setName(String name) {
+    this.name = name;
+  }
+
   public String getType() {
     return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
   }
 
   public boolean ValidForModule(Module module) {


### PR DESCRIPTION
Fixes #514

The DeployKey table schema in DynamoDB was only persisting 3 of 9 fields: id, key, and createdAt. Fields resourceType, scope, source, namespace, provider, name, and type were silently dropped because they were not registered in the enhanced client schema builder. Also added missing setters to DeployKey model for deserialization.