### PR TITLE
fix: resolve CORS errors when creating deploy keys (#406)

### DIFF
--- a/src/main/java/api/router/SpaRouter.java
+++ b/src/main/java/api/router/SpaRouter.java
@@ -23,7 +23,7 @@ public class SpaRouter {
       "/tapir/",
       "/search/",
       "/reports/",
-      "/management/deploykey/",
+      "/management/deploykey",
       "/.well-known/"
   };
   private static final Predicate<String> FILE_NAME_PREDICATE =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -173,6 +173,7 @@ quarkus:
       origins: ${registry.cors.origins}
       methods: "*"
       headers: "*"
+      access-control-allow-credentials: true
 
 "%dev":
    registry:


### PR DESCRIPTION
Fixes #406

Add access-control-allow-credentials: true to default CORS config, required for credentialed requests with cookies. Also fix trailing slash mismatch in SpaRouter path prefix for /management/deploykey.