### PR TITLE
feat: expose provider dependencies on module details (#483)

### DIFF
--- a/src/main/java/core/backend/IRepository.java
+++ b/src/main/java/core/backend/IRepository.java
@@ -38,6 +38,8 @@ public interface IRepository {
 
   DeployKey getDeployKeyByValue(String value) throws DeployKeyNotFoundException;
 
+  void updateModuleProviderDependencies(Module module) throws Exception;
+
   void saveDeployKey(DeployKey deployKey) throws Exception;
 
   void updateDeployKey(DeployKey deployKey) throws Exception;

--- a/src/main/java/core/backend/aws/dynamodb/converter/ModuleProviderDependenciesConverter.java
+++ b/src/main/java/core/backend/aws/dynamodb/converter/ModuleProviderDependenciesConverter.java
@@ -1,0 +1,44 @@
+package core.backend.aws.dynamodb.converter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import core.terraform.Module.ModuleProviderDependency;
+import java.util.List;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class ModuleProviderDependenciesConverter implements AttributeConverter<List<ModuleProviderDependency>> {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Override
+  public AttributeValue transformFrom(List<ModuleProviderDependency> dependencies) {
+    try {
+      return AttributeValue.fromS(MAPPER.writeValueAsString(dependencies));
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to serialize provider dependencies", e);
+    }
+  }
+
+  @Override
+  public List<ModuleProviderDependency> transformTo(AttributeValue attributeValue) {
+    try {
+      return MAPPER.readValue(attributeValue.s(),
+          new TypeReference<List<ModuleProviderDependency>>() {});
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to deserialize provider dependencies", e);
+    }
+  }
+
+  @Override
+  public EnhancedType<List<ModuleProviderDependency>> type() {
+    return EnhancedType.listOf(ModuleProviderDependency.class);
+  }
+
+  @Override
+  public AttributeValueType attributeValueType() {
+    return AttributeValueType.S;
+  }
+}

--- a/src/main/java/core/backend/aws/dynamodb/repository/DynamodbRepository.java
+++ b/src/main/java/core/backend/aws/dynamodb/repository/DynamodbRepository.java
@@ -87,6 +87,15 @@ public class DynamodbRepository extends TapirRepository {
   }
 
   @Override
+  public void updateModuleProviderDependencies(Module module) {
+    Module existingModule = modulesTable.getItem(module);
+    if (existingModule != null) {
+      existingModule.setProviderDependencies(module.getProviderDependencies());
+      modulesTable.updateItem(existingModule);
+    }
+  }
+
+  @Override
   public void ingestProviderData(Provider provider) {
     Provider providerToIngest;
     Provider existingProvider = providerTable.getItem(provider);

--- a/src/main/java/core/backend/aws/dynamodb/repository/TableSchemas.java
+++ b/src/main/java/core/backend/aws/dynamodb/repository/TableSchemas.java
@@ -4,6 +4,7 @@ import core.tapir.DeployKey;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primaryPartitionKey;
 
 import core.backend.aws.dynamodb.converter.ArtifactVersionsConverter;
+import core.backend.aws.dynamodb.converter.ModuleProviderDependenciesConverter;
 import core.backend.aws.dynamodb.converter.ProviderPlatformsConverter;
 import core.backend.aws.dynamodb.converter.SecurityReportConverter;
 import core.backend.aws.dynamodb.converter.TerraformDocumentationConverter;
@@ -12,6 +13,7 @@ import core.terraform.Provider;
 import extensions.core.Report;
 import extensions.docs.report.TerraformDocumentation;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -69,6 +71,10 @@ public class TableSchemas {
                   .addAttribute(Instant.class, a -> a.name("published_at")
                           .getter(Module::getPublished_at)
                           .setter(Module::setPublished_at))
+                  .addAttribute(List.class, a -> a.name("providerDependencies")
+                          .getter(Module::getProviderDependencies)
+                          .setter(Module::setProviderDependencies)
+                          .attributeConverter((AttributeConverter) new ModuleProviderDependenciesConverter()))
                   .build();
 
   static final TableSchema<Report> reportsTableSchema =

--- a/src/main/java/core/backend/azure/cosmosdb/CosmosDbRepository.java
+++ b/src/main/java/core/backend/azure/cosmosdb/CosmosDbRepository.java
@@ -176,6 +176,25 @@ public class CosmosDbRepository extends TapirRepository {
   }
 
   @Override
+  public void updateModuleProviderDependencies(Module module) {
+    try {
+      Module existingModule = modulesContainer.readItem(
+          module.getId(),
+          new PartitionKey(module.getId()),
+          Module.class
+      ).getItem();
+      existingModule.setProviderDependencies(module.getProviderDependencies());
+      modulesContainer.upsertItem(
+          existingModule,
+          new PartitionKey(module.getId()),
+          new CosmosItemRequestOptions()
+      );
+    } catch (NotFoundException e) {
+      // Module doesn't exist yet, nothing to update
+    }
+  }
+
+  @Override
   public void ingestProviderData(Provider provider) {
     Provider providerToIngest;
     try {

--- a/src/main/java/core/backend/elasticsearch/ElasticSearchRepository.java
+++ b/src/main/java/core/backend/elasticsearch/ElasticSearchRepository.java
@@ -166,6 +166,27 @@ public class ElasticSearchRepository extends TapirRepository {
   }
 
   @Override
+  public void updateModuleProviderDependencies(Module module) throws IOException {
+    String docId = String.format("%s-%s-%s", module.getNamespace(), module.getName(), module.getProvider());
+    try {
+      Request request = new Request(
+          HttpMethod.POST,
+          String.format("/%s/_update/%s?refresh=wait_for", moduleIndexName, docId)
+      );
+      JsonObject doc = new JsonObject();
+      if (module.getProviderDependencies() != null) {
+        doc.put("providerDependencies",
+            new JsonObject(io.vertx.core.json.Json.encode(module.getProviderDependencies())));
+      }
+      String payload = JsonObject.of("doc", doc).toString();
+      request.setJsonEntity(payload);
+      restClient.performRequest(request);
+    } catch (ResponseException e) {
+      // Module doesn't exist yet, nothing to update
+    }
+  }
+
+  @Override
   public void ingestProviderData(Provider provider) throws IOException {
     Request request = new Request(
             HttpMethod.POST,

--- a/src/main/java/core/terraform/Module.java
+++ b/src/main/java/core/terraform/Module.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import core.tapir.CoreEntity;
 import jakarta.validation.constraints.NotEmpty;
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -38,6 +39,7 @@ public class Module extends CoreEntity {
   private String provider;
   private Instant published_at;
   private Integer downloads = 0;
+  private List<ModuleProviderDependency> providerDependencies;
 
   @JsonIgnore
   public String getCurrentVersion() {
@@ -104,6 +106,45 @@ public class Module extends CoreEntity {
     this.downloads = downloads;
   }
 
+  public List<ModuleProviderDependency> getProviderDependencies() {
+    return providerDependencies;
+  }
+
+  public void setProviderDependencies(List<ModuleProviderDependency> providerDependencies) {
+    this.providerDependencies = providerDependencies;
+  }
+
+  public static class ModuleProviderDependency {
+    private String name;
+    private String source;
+    private String version;
+
+    public ModuleProviderDependency() {}
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getSource() {
+      return source;
+    }
+
+    public void setSource(String source) {
+      this.source = source;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    public void setVersion(String version) {
+      this.version = version;
+    }
+  }
 }
 
 

--- a/src/main/java/core/vertx/event/consumer/ReportListener.java
+++ b/src/main/java/core/vertx/event/consumer/ReportListener.java
@@ -2,6 +2,7 @@ package core.vertx.event.consumer;
 
 import core.backend.TapirRepository;
 import core.terraform.Module;
+import core.terraform.Module.ModuleProviderDependency;
 import core.upload.FormData;
 import extensions.core.Report;
 import extensions.docs.report.TerraformDocumentation;
@@ -12,6 +13,7 @@ import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -52,6 +54,7 @@ public class ReportListener {
     report.setSecurityReport(securityReport);
     report.setDocumentation(documentation);
     eventBus.requestAndForget("module.report.finished", report);
+    updateModuleProviderDependencies(module, documentation);
     return "ok";
   }
 
@@ -63,5 +66,20 @@ public class ReportListener {
     );
     tapirRepository.ingestSecurityScanResult(report);
     return "ok";
+  }
+
+  private void updateModuleProviderDependencies(Module module, TerraformDocumentation documentation) throws Exception {
+    if (documentation == null || documentation.getProviders() == null || documentation.getProviders().isEmpty()) {
+      return;
+    }
+    List<ModuleProviderDependency> deps = new ArrayList<>();
+    for (TerraformDocumentation.Provider docProvider : documentation.getProviders()) {
+      ModuleProviderDependency dep = new ModuleProviderDependency();
+      dep.setName(docProvider.getName());
+      dep.setVersion(docProvider.getVersion());
+      deps.add(dep);
+    }
+    module.setProviderDependencies(deps);
+    tapirRepository.updateModuleProviderDependencies(module);
   }
 }


### PR DESCRIPTION
Fixes #483

Provider dependencies parsed by terraform-docs are now attached to the Module model and surfaced through the module API. 

Changes:
- Added providerDependencies field to Module.java with ModuleProviderDependency inner class
- Added DynamoDB converter and schema entry for the new field
- Implemented updateModuleProviderDependencies in all 3 backends (DynamoDB, CosmosDB, Elasticsearch)
- Wired ReportListener to extract provider deps from terraform-docs output and persist them