### PR TITLE
fix: improve deploy key validation error handling for module publish (#500)

### DIFF
--- a/src/main/java/api/auth/ApiKeyAuthenticationMechanism.java
+++ b/src/main/java/api/auth/ApiKeyAuthenticationMechanism.java
@@ -84,12 +84,24 @@ public class ApiKeyAuthenticationMechanism implements HttpAuthenticationMechanis
     return deployKeyService.getDeployKeyByValue(apiKeyHeader);
   }
   private boolean validateKeyByRequestPath(DeployKey key, String requestPath) {
-    String resourceId = requestPath.split("/v1/")[1];
-    String[] split = resourceId.split("/");
+    String[] parts = requestPath.split("/v1/");
+    if (parts.length < 2) {
+      LOGGER.warning("Invalid request path format (missing /v1/): " + requestPath);
+      return false;
+    }
+    String[] split = parts[1].split("/");
     if (requestPath.contains("modules")) {
+      if (split.length < 3) {
+        LOGGER.warning("Invalid module path format: " + requestPath);
+        return false;
+      }
       Module module = new Module(split[0], split[1], split[2]);
       return key.ValidForModule(module);
     } else {
+      if (split.length < 2) {
+        LOGGER.warning("Invalid provider path format: " + requestPath);
+        return false;
+      }
       Provider provider = new Provider(split[0], split[1]);
       return key.ValidForProvider(provider);
     }


### PR DESCRIPTION
Fixes #500

Add defensive path parsing and validation to validateKeyByRequestPath to prevent ArrayIndexOutOfBoundsException and provide clearer error messages when deploy key validation fails during module/provider upload.